### PR TITLE
修复获取剧情纯文本方法中的bug

### DIFF
--- a/src/ArknightsResources.Stories.Models.csproj
+++ b/src/ArknightsResources.Stories.Models.csproj
@@ -16,9 +16,9 @@
     <PackageIcon>icon.png</PackageIcon>
     <Description>Provides models about Arknights stories</Description>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.2.0.0-alpha</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.1.0-alpha</Version>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>

--- a/src/StoryScene.cs
+++ b/src/StoryScene.cs
@@ -128,25 +128,14 @@ namespace ArknightsResources.Stories.Models
                         }
 
                         ShowMultilineCommand smcLast = null;
-                        int handledCommands = 0;
                         IEnumerable<ShowMultilineCommand> cmdSegment = from cmd
                                          in textCommands.Skip(i + 1)
                                                         .TakeWhile((cmd) =>
                                                         {
-                                                            handledCommands++;
                                                             if (!(cmd is ShowMultilineCommand smc))
                                                             {
-                                                                if (handledCommands > 15)
-                                                                {
-                                                                    //处理的非Multiline命令超过了15个,这是不正常的
-                                                                    //Multiline命令应当是比较连续的
-                                                                    //我们很有可能已经离开了Multiline命令的作用范围
-                                                                    //所以我们应当停止Take操作
-                                                                    return false;
-                                                                }
-
-                                                                //如果cmd不是ShowMultilineCommand命令,则返回true,继续Take操作
-                                                                return true;
+                                                                //如果cmd不是ShowMultilineCommand命令,则返回false,结束Take操作
+                                                                return false;
                                                             }
                                                             else
                                                             {


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
修复在获取剧情纯文本时，由于没有及时结束过程导致获取到意外字符的问题
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复 
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
在获取某些包含multiline命令的文件时，StoryScene的GetStoryText方法可能会将后面的multiline文本提前插入到前面的multiline文本中，导致文本出错。
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
改进了判断，现在GetStoryText将及时结束multiline命令获取
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->